### PR TITLE
rate of growth based upon 3 day EMA - 7 day EMA

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -7,6 +7,12 @@ const TYPES = [
     "min": 200,
   },
   {
+    "id": "confirmed_trend",
+    "name": "confirmed_trend",
+    "max": 30,
+    "min": 0,
+  },
+  {
     "id": "confirmed_delta",
     "name": "confirmed Δ",
     "max": 0.5,

--- a/js/index.js
+++ b/js/index.js
@@ -8,7 +8,7 @@ const TYPES = [
   },
   {
     "id": "confirmed_trend",
-    "name": "confirmed_trend",
+    "name": "confirmed trend",
     "max": 30,
     "min": 0,
   },


### PR DESCRIPTION
This is an attempt to visualize what I had mentioned in my comment.   The basic formula uses the EMA (exponential moving average), specifically the difference between the 3 and 7 day EMAs of confirmed cases, divided by the confirmed case count to normalize it.  
`(3 day ema - 7 day ema) / count`  

For some reason I need to select the "confirmed" cases before the "confirmed trend" actually works, probably coz I kinda hacked this in there :)