### PR TITLE
Add raw growth rate as a data type

### DIFF
--- a/js/helpers.js
+++ b/js/helpers.js
@@ -56,7 +56,7 @@ function normalizeDataSet(sortedDataSet, userPreferences) {
 }
 
 function getNormalizedType(types, type) {
-  if (type.id == "confirmed_delta") {
+  if (type.id == "confirmed_delta" || type.id == "growth_rate") {
     return getType(types, "confirmed");
   }
   if (type.id == "active_delta") {
@@ -90,6 +90,14 @@ function calculateValue(daysSet, idx, type) {
     }
     return (value / valuePrev) - 1;
   }
+  if (type == "growth_rate") {
+    let value = calculateValue(daysSet, idx, "confirmed_delta");
+    let valuePrev = calculateValue(daysSet, idx - 1, "confirmed_delta");
+    if (valuePrev === 0) {
+      return 0;
+    }
+    return value / valuePrev;
+  }
   return day[type];
 }
 
@@ -115,6 +123,10 @@ function formatValue(value, userPreferences) {
       || userPreferences.selectedType == "active_delta"
   ) {
     return value.toLocaleString(undefined, { style: "percent" });
+  }
+
+  if (userPreferences.selectedType == "growth_rate") {
+    return value.toLocaleString(undefined, { maximumFractionDigits: 2 })
   }
 
   return value;

--- a/js/index.js
+++ b/js/index.js
@@ -13,6 +13,12 @@ const TYPES = [
     "min": 0.0,
   },
   {
+    "id": "growth_rate",
+    "name": "growth rate",
+    "max": 2.0,
+    "min": 1.0,
+  },
+  {
     "id": "deaths",
     "name": "deaths",
     "max": 4000,


### PR DESCRIPTION
This is an implementation of the naive definition of the growth rate, defined as `delta(day, day-1) / delta(day-1, day-2)`. It's naive because the real-life data has an uneven distribution of number of tests performed over time.

#8 is a better-looking approach. Feel free to not merge this; I was curious what the raw growth rate calculated from day to day would look like. I don't think it looks great, but it might be an interesting data point nonetheless.

![image](https://user-images.githubusercontent.com/265818/77346690-f556f600-6d36-11ea-9268-348c06a36cd3.png)
