### PR TITLE
Add auto normalization based on showing at least 5 dates for all selected regions

### DIFF
--- a/src/components/Controls.vue
+++ b/src/components/Controls.vue
@@ -15,6 +15,7 @@
       type="text"
       :value="normalizationValue"
       v-on:change="setNormalizationValue"
+      :placeholder="autoNormalizedValue"
     />
     <input v-model="regionSearchText" placeholder="Search..." />
     <select multiple @change="setSelectedRegions" class="regions">
@@ -73,6 +74,9 @@ export default {
     },
     normalizationValue() {
       return this.$store.state.selection.normalizationValue;
+    },
+    autoNormalizedValue() {
+      return this.$store.getters.autoNormalizedValue;
     }
   },
   methods: {
@@ -84,8 +88,12 @@ export default {
       this.$store.commit("setSelectedRegions", values);
     },
     setNormalizationValue(e) {
-      const value = parseInt(e.target.value);
-      this.$store.commit("setNormalizationValue", value);
+      if (e.target.value.length === 0) {
+        this.$store.commit("setNormalizationValue", null);
+      } else {
+        const value = parseInt(e.target.value);
+        this.$store.commit("setNormalizationValue", value);
+      }
     }
   }
 };


### PR DESCRIPTION
Found a simple way to auto-normalize.

I look at all selected regions and check which one has the lowest value within 5 dates from the latest.

I then round that date to its floor of the largest digit (`21312` -> `20000`) and use it for normalization.